### PR TITLE
Fix "confirmation" validation by passing `model` and `attribute` arguments along to `validate`

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -94,7 +94,13 @@ export default function validationState(VALIDATOR_FNS) {
  */
 export function validate(eventName, context, model, attribute) {
   return function (value, messageSvc) {
-    const validOrContext = _validate(eventName, value, context, model, attribute);
+    const validOrContext = _validate(
+      eventName,
+      value,
+      context,
+      model,
+      attribute
+    );
 
     if (typeof validOrContext === 'boolean') {
       return [true];

--- a/addon/index.js
+++ b/addon/index.js
@@ -92,9 +92,9 @@ export default function validationState(VALIDATOR_FNS) {
  * @param {object} context - the options hash passed along to ember-validators
  * @returns {function<*, MessageBuilder>: [isValid: boolean, message?: string]}
  */
-export function validate(eventName, context) {
+export function validate(eventName, context, model, attribute) {
   return function (value, messageSvc) {
-    const validOrContext = _validate(eventName, value, context);
+    const validOrContext = _validate(eventName, value, context, model, attribute);
 
     if (typeof validOrContext === 'boolean') {
       return [true];

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,21 +1,21 @@
 type Validators = Record<string, any[]>;
 
-type AttributeValidation = {
+interface AttributeValidation {
   messages: string[];
   isValid: boolean;
-};
+}
 
 type AttrsType<T> = {
   [P in keyof T]: AttributeValidation;
 };
 
-export type ValidationState<A> = {
+export interface ValidationState<A> {
   isValid: boolean;
   attrs: AttrsType<A>;
-};
+}
 
-export function validate(any, any): any;
+export function validate(validatorName: any, context: any, model?: any, attribute?: string): any;
 
 export default function validationState(
   validators: Validators | ((ctx: any) => Validators)
-): PropertyDescriptor<ValidationState<typeof validators>>;
+): <T>(target: T, key: keyof T) => void;


### PR DESCRIPTION
Hi! 👋 

I'm using your addon in my project and fell on an issue: the "confirmation" validation does not work if we don't pass it a `model`. I checked the code in `ember-validators` and all validators receive a `model` and `attribute` argument (even if they don't use it!) so I forwarded them to fix my issue.

I also fixed the types for the `@validationState` decorator since it didn't pass type check.